### PR TITLE
#3 Improved Import dialog error handling

### DIFF
--- a/src/apps/FFHacksterEx/FFHacksterEx.rc
+++ b/src/apps/FFHacksterEx/FFHacksterEx.rc
@@ -275,7 +275,7 @@ BEGIN
                     "Button",BS_AUTOCHECKBOX | BS_FLAT | WS_TABSTOP,7,99,201,10
     PUSHBUTTON      "Browse",IDC_BUTTON2,7,110,50,14,BS_FLAT
     EDITTEXT        IDC_EDIT2,62,110,240,14,ES_AUTOHSCROLL
-    LTEXT           "Note that the Labels will overwrite similar data imported from the DAT if both are selected.",IDC_STATIC,7,136,181,16
+    LTEXT           "Note that the Project into will overwrite similar data imported from the DAT if both are selected.",IDC_STATIC,7,136,181,16
     DEFPUSHBUTTON   "OK",IDOK,198,137,50,14,BS_FLAT
     PUSHBUTTON      "Cancel",IDCANCEL,252,137,50,14,BS_FLAT
 END

--- a/src/apps/FFHacksterEx/FFHacksterEx.rc
+++ b/src/apps/FFHacksterEx/FFHacksterEx.rc
@@ -275,7 +275,7 @@ BEGIN
                     "Button",BS_AUTOCHECKBOX | BS_FLAT | WS_TABSTOP,7,99,201,10
     PUSHBUTTON      "Browse",IDC_BUTTON2,7,110,50,14,BS_FLAT
     EDITTEXT        IDC_EDIT2,62,110,240,14,ES_AUTOHSCROLL
-    LTEXT           "Note that the Project into will overwrite similar data imported from the DAT if both are selected.",IDC_STATIC,7,136,181,16
+    LTEXT           "Note that the Project info will overwrite similar data imported from the DAT if both are selected.",IDC_STATIC,7,136,181,16
     DEFPUSHBUTTON   "OK",IDOK,198,137,50,14,BS_FLAT
     PUSHBUTTON      "Cancel",IDCANCEL,252,137,50,14,BS_FLAT
 END


### PR DESCRIPTION
The project options are only considered if at least one of its boxes is checked.
Refactor of project code to  condense it and slightly improve error handling.
So the dialog should no longer show an errro message if importing a DAT and not importing any project options.