### PR TITLE
#11 Fix Sprite Editor assigning formation 1 battles

### DIFF
--- a/src/libs/ff1-utils/editor_label_functions.cpp
+++ b/src/libs/ff1-utils/editor_label_functions.cpp
@@ -146,7 +146,7 @@ namespace Editorlabels
 				if (showindex) name.Format("%02X: ", d.value);
 				name.AppendFormat("%s", d.name);
 				dataintnode dx(name, d.value);
-				v.push_back(d);
+				v.push_back(dx);
 			}
 		}
 		for (const auto& d : labels) {


### PR DESCRIPTION
Passing the wrong variable led to the formation 1 battles having the wrong format.