### PR TITLE
Turn off High-DPI aware setting for FFHacksterEx x64

### DIFF
--- a/src/apps/FFHacksterEx/FFHacksterEx.vcxproj
+++ b/src/apps/FFHacksterEx/FFHacksterEx.vcxproj
@@ -325,6 +325,9 @@
     </ResourceCompile>
     <PostBuildEvent />
     <PostBuildEvent />
+    <Manifest>
+      <EnableDpiAwareness>false</EnableDpiAwareness>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -386,6 +389,9 @@
     </ResourceCompile>
     <PostBuildEvent />
     <PostBuildEvent />
+    <Manifest>
+      <EnableDpiAwareness>false</EnableDpiAwareness>
+    </Manifest>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
Turning off the DPI awareness settings provides immediate relief for those on scaled displays.
We can create a new ticket if there's a need to implement true scaling instead of relying on system-provided scaling.
For issue #18