### PR TITLE
#74 Hold CTRL for faster scrolling on std and overworld maps

### DIFF
--- a/src/libs/ff1-editors/Maps.cpp
+++ b/src/libs/ff1-editors/Maps.cpp
@@ -901,10 +901,10 @@ void CMaps::OnHScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar)
 	UNREFERENCED_PARAMETER(pScrollBar);
 
 	switch (nSBCode) {
-	case 0: ScrollOffset.x -= 1; break;
-	case 1: ScrollOffset.x += 1; break;
-	case 2: ScrollOffset.x -= 16; break;
-	case 3: ScrollOffset.x += 16; break;
+	case 0: ScrollOffset.x -= 1 * Ui::MultiplyIf(8); break;
+	case 1: ScrollOffset.x += 1 * Ui::MultiplyIf(8); break;
+	case 2: ScrollOffset.x -= 16 * Ui::MultiplyIf(2); break;
+	case 3: ScrollOffset.x += 16 * Ui::MultiplyIf(2); break;
 	case 5: ScrollOffset.x = nPos; break;
 	}
 	if (ScrollOffset.x < 0) ScrollOffset.x = 0;
@@ -920,10 +920,10 @@ void CMaps::OnVScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar)
 	UNREFERENCED_PARAMETER(pScrollBar);
 
 	switch (nSBCode) {
-	case 0: ScrollOffset.y -= 1; break;
-	case 1: ScrollOffset.y += 1; break;
-	case 2: ScrollOffset.y -= 16; break;
-	case 3: ScrollOffset.y += 16; break;
+	case 0: ScrollOffset.y -= 1 * Ui::MultiplyIf(8); break;
+	case 1: ScrollOffset.y += 1 * Ui::MultiplyIf(8); break;
+	case 2: ScrollOffset.y -= 16 * Ui::MultiplyIf(1); break;
+	case 3: ScrollOffset.y += 16 * Ui::MultiplyIf(1); break;
 	case 5: ScrollOffset.y = nPos; break;
 	}
 	if (ScrollOffset.y < 0) ScrollOffset.y = 0;

--- a/src/libs/ff1-editors/OverworldMap.cpp
+++ b/src/libs/ff1-editors/OverworldMap.cpp
@@ -1056,10 +1056,10 @@ void COverworldMap::handle_hscroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollB
 	UNREFERENCED_PARAMETER(pScrollBar);
 
 	switch (nSBCode) {
-	case SB_LINELEFT: ScrollOffset.x -= 1; break;
-	case SB_LINERIGHT: ScrollOffset.x += 1; break;
-	case SB_PAGELEFT: ScrollOffset.x -= 16; break;
-	case SB_PAGERIGHT: ScrollOffset.x += 16; break;
+	case SB_LINELEFT: ScrollOffset.x -= 1 * Ui::MultiplyIf(8); break;
+	case SB_LINERIGHT: ScrollOffset.x += 1 * Ui::MultiplyIf(8); break;
+	case SB_PAGELEFT: ScrollOffset.x -= 16 * Ui::MultiplyIf(2); break;
+	case SB_PAGERIGHT: ScrollOffset.x += 16 * Ui::MultiplyIf(2); break;
 	case SB_THUMBTRACK: ScrollOffset.x = nPos; break;
 	}
 	auto maxes = calc_scroll_maximums();
@@ -1087,10 +1087,10 @@ void COverworldMap::handle_vscroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollB
 	UNREFERENCED_PARAMETER(pScrollBar);
 
 	switch (nSBCode) {
-	case SB_LINEUP: ScrollOffset.y -= 1; break;
-	case SB_LINEDOWN: ScrollOffset.y += 1; break;
-	case SB_PAGEUP: ScrollOffset.y -= 16; break;
-	case SB_PAGEDOWN: ScrollOffset.y += 16; break;
+	case SB_LINEUP: ScrollOffset.y -= 1 * Ui::MultiplyIf(8); break;
+	case SB_LINEDOWN: ScrollOffset.y += 1 * Ui::MultiplyIf(8); break;
+	case SB_PAGEUP: ScrollOffset.y -= 16 * Ui::MultiplyIf(2); break;
+	case SB_PAGEDOWN: ScrollOffset.y += 16 * Ui::MultiplyIf(2); break;
 	case SB_THUMBTRACK: ScrollOffset.y = nPos; break;
 	}
 	auto maxes = calc_scroll_maximums();

--- a/src/libs/ff1-subeditors/CSubDlgRenderMap.cpp
+++ b/src/libs/ff1-subeditors/CSubDlgRenderMap.cpp
@@ -80,7 +80,7 @@ BOOL CSubDlgRenderMap::init()
 
 int CSubDlgRenderMap::handle_scroll(UINT nBar, UINT nSBCode, UINT nPos)
 {
-	return Ui::HandleClientScroll(this, nBar, nSBCode, nPos);
+	return Ui::HandleClientScroll(this, nBar, nSBCode, nPos, 8, 2);
 }
 
 void CSubDlgRenderMap::handle_sizing()

--- a/src/libs/ff1-subeditors/DlgPopoutMap.cpp
+++ b/src/libs/ff1-subeditors/DlgPopoutMap.cpp
@@ -466,7 +466,7 @@ void CDlgPopoutMap::OnPaint()
 
 void CDlgPopoutMap::OnHScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar)
 {
-	Ui::HandleContainedScroll(&m_hscroll, SB_HORZ, nSBCode, nPos);
+	Ui::HandleContainedScroll(&m_hscroll, SB_HORZ, nSBCode, nPos, 8, 2);
 	invalidate_display_area();
 	CDialogEx::OnHScroll(nSBCode, nPos, pScrollBar);
 	Editor->HandleAfterScroll(get_scroll_pos(), get_display_area());
@@ -474,7 +474,7 @@ void CDlgPopoutMap::OnHScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar)
 
 void CDlgPopoutMap::OnVScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar)
 {
-	Ui::HandleContainedScroll(&m_vscroll, SB_VERT, nSBCode, nPos);
+	Ui::HandleContainedScroll(&m_vscroll, SB_VERT, nSBCode, nPos, 8, 2);
 	invalidate_display_area();
 	CDialogEx::OnVScroll(nSBCode, nPos, pScrollBar);
 	Editor->HandleAfterScroll(get_scroll_pos(), get_display_area());

--- a/src/libs/ff1-utils/ui_helpers.cpp
+++ b/src/libs/ff1-utils/ui_helpers.cpp
@@ -499,36 +499,47 @@ namespace Ui
 
 	int HandleClientScroll(CWnd* pwnd, UINT nBar, UINT nSBCode, UINT nPos)
 	{
+		return HandleClientScroll(pwnd, nBar, nSBCode, nPos, 1, 1);
+	}
+
+	int HandleClientScroll(CWnd* pwnd, UINT nBar, UINT nSBCode, UINT nPos,
+		int arrowmultiplier, int pagemultiplier)
+	{
+		ASSERT(arrowmultiplier > 0);
+		ASSERT(pagemultiplier > 0);
+		if (arrowmultiplier < 1) arrowmultiplier = 1;
+		if (pagemultiplier < 1) pagemultiplier = 1;
+
 		int curpos = pwnd->GetScrollPos(nBar);
 		int limit = pwnd->GetScrollLimit(nBar);
 		switch (nSBCode)
 		{
-		case SB_LEFT: // == SB_TOP
+		case SB_LEFT:
 			curpos = 0;
 			break;
-		case SB_RIGHT: // == SB_BOTTOM
+		case SB_RIGHT:
 			curpos = limit;
 			break;
 		case SB_ENDSCROLL:
 			break;
-		case SB_LINELEFT: // == SB_LINEUP
-			if (curpos > 0) --curpos;
+		case SB_LINELEFT:
+			curpos -= 1 * Ui::MultiplyIf(arrowmultiplier);
 			break;
-		case SB_LINERIGHT: // == SB_LINEDOWN
-			if (curpos < limit) ++curpos;
+		case SB_LINERIGHT:
+			curpos += 1 * Ui::MultiplyIf(arrowmultiplier);
 			break;
-		case SB_PAGELEFT: // == SB_PAGEUP
+		case SB_PAGELEFT:
 		{
 			SCROLLINFO info;
 			pwnd->GetScrollInfo(nBar, &info, SIF_ALL);
-			if (curpos > 0) curpos = max(0, curpos - (int)info.nPage);
+			curpos -= (int)info.nPage * Ui::MultiplyIf(pagemultiplier);
 		}
 		break;
-		case SB_PAGERIGHT: // == SB_PAGEDOWN
+		case SB_PAGERIGHT:
 		{
 			SCROLLINFO info;
 			pwnd->GetScrollInfo(nBar, &info, SIF_ALL);
-			if (curpos < limit) curpos = min(limit, curpos + (int)info.nPage);
+			curpos += (int)info.nPage * Ui::MultiplyIf(pagemultiplier);
 		}
 		break;
 		case SB_THUMBPOSITION:
@@ -539,6 +550,8 @@ namespace Ui
 			break;          // This occurs when dragging the scroll box with the mouse.
 		}
 
+		if (curpos < 0) curpos = 0;
+		else if (curpos > limit) curpos = limit;
 		pwnd->SetScrollPos(nBar, curpos);
 		return curpos;
 	}
@@ -578,36 +591,47 @@ namespace Ui
 
 	int HandleContainedScroll(CScrollBar* bar, UINT nBar, UINT nSBCode, UINT nPos)
 	{
+		return HandleContainedScroll(bar, nBar, nSBCode, nPos, 1, 1);
+	}
+
+	int HandleContainedScroll(CScrollBar* bar, UINT nBar, UINT nSBCode, UINT nPos,
+		int arrowmultiplier, int pagemultiplier)
+	{
+		ASSERT(arrowmultiplier > 0);
+		ASSERT(pagemultiplier > 0);
+		if (arrowmultiplier < 1) arrowmultiplier = 1;
+		if (pagemultiplier < 1) pagemultiplier = 1;
+
 		int curpos = bar->GetScrollPos();
 		int limit = bar->GetScrollLimit();
 		switch (nSBCode)
 		{
-		case SB_LEFT: // == SB_TOP
+		case SB_LEFT:
 			curpos = 0;
 			break;
-		case SB_RIGHT: // == SB_BOTTOM
+		case SB_RIGHT:
 			curpos = limit;
 			break;
 		case SB_ENDSCROLL:
 			break;
-		case SB_LINELEFT: // == SB_LINEUP
-			if (curpos > 0) --curpos;
+		case SB_LINELEFT:
+			curpos -= 1 * Ui::MultiplyIf(arrowmultiplier);
 			break;
-		case SB_LINERIGHT: // == SB_LINEDOWN
-			if (curpos < limit) ++curpos;
+		case SB_LINERIGHT:
+			curpos += 1 * Ui::MultiplyIf(arrowmultiplier);
 			break;
-		case SB_PAGELEFT: // == SB_PAGEUP
+		case SB_PAGELEFT:
 		{
 			SCROLLINFO info;
 			bar->GetScrollInfo(&info, SIF_ALL);
-			if (curpos > 0) curpos = max(0, curpos - (int)info.nPage);
+			curpos -= (int)info.nPage * Ui::MultiplyIf(pagemultiplier);
 		}
 		break;
-		case SB_PAGERIGHT: // == SB_PAGEDOWN
+		case SB_PAGERIGHT:
 		{
 			SCROLLINFO info;
 			bar->GetScrollInfo(&info, SIF_ALL);
-			if (curpos < limit) curpos = min(limit, curpos + (int)info.nPage);
+			curpos += (int)info.nPage * Ui::MultiplyIf(pagemultiplier);
 		}
 		break;
 		case SB_THUMBPOSITION:
@@ -618,6 +642,8 @@ namespace Ui
 			break;          // This occurs when dragging the scroll box with the mouse.
 		}
 
+		if (curpos < 0) curpos = 0;
+		else if (curpos > limit) curpos = limit;
 		bar->SetScrollPos(curpos);
 		return curpos;
 	}
@@ -1153,6 +1179,11 @@ namespace Ui
 	LRESULT SendLbnSelchangeToParent(CWnd * wnd)
 	{
 		return SendNotificationToParent(wnd, LBN_SELCHANGE);
+	}
+
+	int MultiplyIf(int multiplier)
+	{
+		return IsKeyDown(VK_CONTROL) ? multiplier : 1;
 	}
 
 } // end namespace Ui

--- a/src/libs/ff1-utils/ui_helpers.h
+++ b/src/libs/ff1-utils/ui_helpers.h
@@ -109,9 +109,13 @@ namespace Ui
 	bool SetClientScroll(CWnd* wnd, int nBar, const CRect& rcarea,
 		int clientextent, int tilespan = 0);
 	int HandleClientScroll(CWnd* pwnd, UINT nBar, UINT nSBCode, UINT nPos);
+	int HandleClientScroll(CWnd* pwnd, UINT nBar, UINT nSBCode, UINT nPos,
+		int arrowmultiplier, int pagemultiplier = 1);
 	bool SetContainedScroll(CScrollBar* bar, int nBar, const CRect& rcarea,
 		int clientextent, int tilespan);
 	int HandleContainedScroll(CScrollBar* bar, UINT nBar, UINT nSBCode, UINT nPos);
+	int HandleContainedScroll(CScrollBar* bar, UINT nBar, UINT nSBCode, UINT nPos,
+		int arrowmultiplier, int pagemultiplier = 1);
 
 	CRect GetSubitemRect(CListCtrl & list, int item, int subitem);
 	void RenumberList(CListCtrl & list, int subitem, int base, int startat);
@@ -181,4 +185,6 @@ namespace Ui
 	LRESULT SendNotificationToParent(CWnd* wnd, UINT notifyid);
 	LRESULT SendBnClickedToParent(CWnd* wnd);
 	LRESULT SendLbnSelchangeToParent(CWnd* wnd);
+
+	int MultiplyIf(int multiplier);
 }


### PR DESCRIPTION
Bear in mind that CMaps is still using a different popout map class and has different internal handling than COverworldMap.
However, both should function similarly.
The one expected difference is that CMaps' embedded map still scrolls by tiles instead of pixels.