### PR TITLE
#83 Restore sprite drawing for the Overworld popout map

### DIFF
--- a/src/libs/ff1-editors/OverworldMap.cpp
+++ b/src/libs/ff1-editors/OverworldMap.cpp
@@ -1822,7 +1822,7 @@ void COverworldMap::paint_map_elements(CDC& dc, CRect displayarea, CPoint scroll
 	}
 
 	//Draw the sprites
-	CRect rc(0, 0, 16, 16);
+	CRect rc(0, 0, gridvis.cx, gridvis.cy);
 	for (coX = 0; coX < 5; coX++) {
 		pt.x = misccoords[coX].x - gridanchor.x;
 		pt.y = misccoords[coX].y - gridanchor.y;


### PR DESCRIPTION
Forgot to change the paint routine to use the current visible column and row counts instead of the hard-coded 16x16.