### PR TITLE
Feature/overworld domain grid scroll and both map refreshes

### DIFF
--- a/src/libs/ff1-editors/Maps.cpp
+++ b/src/libs/ff1-editors/Maps.cpp
@@ -884,18 +884,16 @@ void CMaps::OnSelchangeMaplist()
 	LoadValues();
 
 	InvalidateRect(rcTiles,0);
-	InvalidateRect(rcMap,0);
-	m_mapdlg.InvalidateMap();
 	InvalidateRect(rcPalettes,0);
 	InvalidateRect(rcPalettes2,0);
+	invalidate_maps();
 }
 
 void CMaps::OnShowrooms()
 {
 	m_showingrooms = Ui::GetCheckValue(m_showrooms);
 	InvalidateRect(rcTiles, 0);
-	InvalidateRect(rcMap, 0);
-	m_mapdlg.InvalidateMap();
+	invalidate_maps();
 }
 
 void CMaps::OnHScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar)
@@ -913,8 +911,7 @@ void CMaps::OnHScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar)
 	if (ScrollOffset.x > 48) ScrollOffset.x = 48;
 
 	m_hscroll.SetScrollPos(ScrollOffset.x);
-	InvalidateRect(rcMap, FALSE);
-	m_mapdlg.InvalidateMap();
+	invalidate_maps();
 }
 
 void CMaps::OnVScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar)
@@ -932,8 +929,7 @@ void CMaps::OnVScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar)
 	if (ScrollOffset.y > 48) ScrollOffset.y = 48;
 
 	m_vscroll.SetScrollPos(ScrollOffset.y);
-	InvalidateRect(rcMap, FALSE);
-	m_mapdlg.InvalidateMap();
+	invalidate_maps();
 }
 
 void CMaps::OnLButtonDown(UINT nFlags, CPoint pt)
@@ -1041,8 +1037,7 @@ void CMaps::OnLButtonDblClk(UINT nFlags, CPoint pt)
 
 			InvalidateRect(rcPalettes, 0);
 			InvalidateRect(rcTiles, 0);
-			InvalidateRect(rcMap, 0);
-			m_mapdlg.InvalidateMap();
+			invalidate_maps();
 		}
 	}
 }
@@ -1086,28 +1081,30 @@ void CMaps::OnRButtonDblClk(UINT nFlags, CPoint pt)
 		CTint dlg;
 		dlg.tintvalue = old;
 		dlg.m_tintvariant = cart->TintVariant;
-		if(dlg.DoModal() == IDOK){
+		if (dlg.DoModal() == IDOK) {
 
 			cart->OK_tiles[cur_map] = 0;
-			cart->GetStandardTiles(cur_map,0).DeleteImageList();
-			cart->GetStandardTiles(cur_map,1).DeleteImageList();
+			cart->GetStandardTiles(cur_map, 0).DeleteImageList();
+			cart->GetStandardTiles(cur_map, 1).DeleteImageList();
 
 			cart->TintTiles[cur_tileset + 1][ref] = (BYTE)dlg.tintvalue;
-			if(cart->TintVariant != dlg.m_tintvariant){
+			if (cart->TintVariant != dlg.m_tintvariant) {
 				cart->TintVariant = (BYTE)dlg.m_tintvariant;
-				cart->ReTintPalette();}
+				cart->ReTintPalette();
+			}
 
 			CLoading dlgmaps;
-			dlgmaps.Create(IDD_LOADING,this);
-			dlgmaps.m_progress.SetRange(0,128);
+			dlgmaps.Create(IDD_LOADING, this);
+			dlgmaps.m_progress.SetRange(0, 128);
 			dlgmaps.m_progress.SetPos(0);
 			dlgmaps.ShowWindow(1);
 
 			ReloadImages(&dlgmaps.m_progress);
 
 			dlgmaps.ShowWindow(0);
-			InvalidateRect(rcTiles,0);
-			InvalidateRect(rcMap,0);}
+			InvalidateRect(rcTiles, 0);
+			invalidate_maps();
+		}
 	}
 }
 
@@ -1146,8 +1143,7 @@ void CMaps::UpdatePics()
 
 	dlg.ShowWindow(0);
 	InvalidateRect(rcTiles,0);
-	InvalidateRect(rcMap,0);
-	m_mapdlg.InvalidateMap();
+	invalidate_maps();
 }
 
 void CMaps::UpdateTileData()
@@ -1267,8 +1263,7 @@ void CMaps::OnSelchangeTileset()
 
 	dlg.ShowWindow(0);
 	InvalidateRect(rcTiles,0);
-	InvalidateRect(rcMap,0);
-	m_mapdlg.InvalidateMap();
+	invalidate_maps();
 	LoadTileData();
 }
 
@@ -1301,8 +1296,7 @@ void CMaps::OnStill()
 void CMaps::OnInroom()
 {
 	Sprite_InRoom[m_sprite_list.GetCurSel()] = m_inroom.GetCheck() != 0;
-	InvalidateRect(rcMap,0);
-	m_mapdlg.InvalidateMap();
+	invalidate_maps();
 }
 
 void CMaps::OnChangeSpritecoordx()
@@ -1311,8 +1305,7 @@ void CMaps::OnChangeSpritecoordx()
 	m_spritecoordx.GetWindowText(text); number = StringToInt_HEX(text);
 	if(number > 0x3F) number = 0x3F;
 	Sprite_Coords[m_sprite_list.GetCurSel()].x = number;
-	InvalidateRect(rcMap,0);
-	m_mapdlg.InvalidateMap();
+	invalidate_maps();
 }
 
 void CMaps::OnChangeSpritecoordy()
@@ -1321,23 +1314,20 @@ void CMaps::OnChangeSpritecoordy()
 	m_spritecoordy.GetWindowText(text); number = StringToInt_HEX(text);
 	if(number > 0x3F) number = 0x3F;
 	Sprite_Coords[m_sprite_list.GetCurSel()].y = number;
-	InvalidateRect(rcMap,0);
-	m_mapdlg.InvalidateMap();
+	invalidate_maps();
 }
 
 void CMaps::OnSelchangeSprite()
 {
 	Sprite_Value[m_sprite_list.GetCurSel()] = (short)m_sprite.GetCurSel();
 	m_spritegraphic.SetCurSel(cart->ROM[MAPSPRITE_PICASSIGNMENT + m_sprite.GetCurSel()]);
-	InvalidateRect(rcMap,0);
-	m_mapdlg.InvalidateMap();
+	invalidate_maps();
 }
 
 void CMaps::OnSelchangeSpritegraphic()
 {
 	cart->ROM[MAPSPRITE_PICASSIGNMENT + Sprite_Value[m_sprite_list.GetCurSel()]] = (BYTE)m_spritegraphic.GetCurSel();
-	InvalidateRect(rcMap, 0);
-	m_mapdlg.InvalidateMap();
+	invalidate_maps();
 }
 
 void CMaps::UpdateClick(CPoint pt)
@@ -1358,8 +1348,7 @@ CPoint CMaps::fix_map_point(CPoint point)
 void CMaps::OnShowlastclick()
 {
 	cart->ShowLastClick = (m_showlastclick.GetCheck() != 0);
-	InvalidateRect(rcMap, 0);
-	m_mapdlg.InvalidateMap();
+	invalidate_maps();
 }
 
 void CMaps::OnCustomtool()
@@ -1528,8 +1517,7 @@ void CMaps::OnMapImport()
 		return;}
 	fread(DecompressedMap,1,0x1000,file);
 	fclose(file);
-	InvalidateRect(rcMap,0);
-	m_mapdlg.InvalidateMap();
+	invalidate_maps();
 }
 
 void CMaps::OnViewcoords()
@@ -1576,15 +1564,13 @@ void CMaps::HandleLButtonDown(UINT nFlags, CPoint point)
 		mousedown = 1;
 		UpdateClick(point);
 		DecompressedMap[point.y][point.x] = (BYTE)cur_tile;
-		InvalidateRect(rcMap, 0);
-		m_mapdlg.InvalidateMap();
+		invalidate_maps();
 	}break;
 	default: {		//fill/smarttools
 		mousedown = 1;
 		UpdateClick(point);
 		rcToolRect.SetRect(point.x, point.y, point.x, point.y);
-		InvalidateRect(rcMap, 0);
-		m_mapdlg.InvalidateMap();
+		invalidate_maps();
 	}break;
 	}
 }
@@ -1605,8 +1591,7 @@ void CMaps::HandleLButtonUp(UINT nFlags, CPoint point)
 				for (coX = rcToolRect.left; coX <= rcToolRect.right; coX++)
 					DecompressedMap[coY][coX] = (BYTE)cur_tile;
 			}
-			InvalidateRect(rcMap, 0);
-			m_mapdlg.InvalidateMap();
+			invalidate_maps();
 		}break;
 
 		default: {			//smarttools
@@ -1755,8 +1740,7 @@ void CMaps::HandleLButtonUp(UINT nFlags, CPoint point)
 			}
 			DecompressedMap[rcToolRect.bottom][rcToolRect.right] = cart->SmartTools[temp][co];
 
-			InvalidateRect(rcMap, 0);
-			m_mapdlg.InvalidateMap();
+			invalidate_maps();
 		}break;
 		}
 		OnFindkab();
@@ -1779,8 +1763,7 @@ void CMaps::HandleRButtonDown(UINT nFlags, CPoint pt)
 	UpdateClick(pt);
 	InvalidateRect(rcTiles, 0);
 	if (m_showlastclick.GetCheck()) {
-		InvalidateRect(rcMap, 0);
-		m_mapdlg.InvalidateMap();
+		invalidate_maps();
 	}
 	if (coords_dlg.m_mouseclick.GetCheck()) {
 		coords_dlg.m_coord_l.SetCurSel(m_maplist.GetCurSel());
@@ -1839,15 +1822,13 @@ void CMaps::HandleMouseMove(UINT nFlags, CPoint newhover)
 			switch (cur_tool) {
 			case 0: {		//pencil
 				DecompressedMap[ptHover.y][ptHover.x] = (BYTE)cur_tile;
-				InvalidateRect(rcMap, 0);
-				m_mapdlg.InvalidateMap();
+				invalidate_maps();
 				break;
 			}
 			default: {		//fill / Smarttools
 				rcToolRect.right = ptHover.x;
 				rcToolRect.bottom = ptHover.y;
-				InvalidateRect(rcMap, 0);
-				m_mapdlg.InvalidateMap();
+				invalidate_maps();
 				break;
 			}
 			}
@@ -1862,8 +1843,7 @@ void CMaps::HandleMouseMove(UINT nFlags, CPoint newhover)
 			m_spritecoordx.SetWindowText(text);
 			text.Format("%X", ptHover.y);
 			m_spritecoordy.SetWindowText(text);
-			InvalidateRect(rcMap, 0);
-			m_mapdlg.InvalidateMap();
+			invalidate_maps();
 		}
 	}
 }
@@ -1931,7 +1911,7 @@ void CMaps::ApplyTileTint(int ref)
 
 		dlgmaps.ShowWindow(0);
 		InvalidateRect(rcTiles, 0);
-		InvalidateRect(rcMap, 0);
+		invalidate_maps();
 	}
 }
 
@@ -2066,6 +2046,12 @@ void CMaps::PopMapDialog(bool in)
 		auto pwnd = GetDlgItem(id);
 		Ui::MoveControlBy(pwnd, slide, 0);
 	}
+}
+
+void CMaps::invalidate_maps()
+{
+	InvalidateRect(rcMap, 0);
+	m_mapdlg.InvalidateMap();
 }
 
 void CMaps::OnBnClickedButtonPopout()

--- a/src/libs/ff1-editors/Maps.h
+++ b/src/libs/ff1-editors/Maps.h
@@ -118,6 +118,7 @@ protected:
 
 	void init_popout_map_window();
 	void PopMapDialog(bool in);
+	void invalidate_maps();
 
 	BYTE MapPalette[2][4][4];
 	BYTE SpritePalette[2][4];

--- a/src/libs/ff1-editors/OverworldMap.h
+++ b/src/libs/ff1-editors/OverworldMap.h
@@ -73,8 +73,8 @@ protected:
 	CFFHacksterProject* cart = nullptr; //FUTURE - replace cart with Project and remove references to cart
 	CImageList m_sprites;
 	CImageList m_backdrop;
+	COLORREF m_gridcolor;
 	CPen redpen;
-	CPen bluepen;
 	CBrush toolBrush;
 	CRect rcTiles;
 	CRect rcMap;
@@ -96,9 +96,11 @@ protected:
 	bool probabilitychanged;
 	BYTE mousedown;
 	int kab;
-	CSize m_mapsize = { 256, 256 };
+	CSize m_mapsize = { 256, 256 }; //TODO - rename to m_maptilesize?
 	CSize m_tiledims = { 16,16 };
-	CSize m_minmapsize = { 16,16 };
+	CSize m_minmapsize = { 16,16 }; //TODO - rename to m_minimaptilesize?
+	CSize m_domaincounts = { 8, 8 };
+	std::vector<CRect> m_domainrects;
 	bool m_firstpopoutdone = false;
 	bool m_popoutcreated = false;
 	std::vector<CDrawingToolButton*> m_toolbuttons;
@@ -126,6 +128,9 @@ protected:
 	CSize get_scroll_limits();
 	void apply_tile_tint(int ref);
 	CRect get_display_area();
+	void build_domain_rects();
+	void invalidate_maps();
+
 	void handle_hscroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar);
 	void handle_vscroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar);
 	void handle_paint(CDC& dc);

--- a/src/libs/ff1-editors/Shop.cpp
+++ b/src/libs/ff1-editors/Shop.cpp
@@ -131,7 +131,7 @@ BOOL CShop::OnInitDialog()
 			LoadCombo(*m_item[co], treasureitems);
 		}
 
-		m_banner.Set(this, COLOR_BLACK, COLOR_GREEN, "Shops");
+		m_banner.Set(this, COLOR_BLACK, COLOR_FFGREEN, "Shops");
 
 		cur_type = -1;
 		m_shoptype.SetCurSel(0);

--- a/src/libs/ff1-subeditors/CSubDlgRenderMap.cpp
+++ b/src/libs/ff1-subeditors/CSubDlgRenderMap.cpp
@@ -67,8 +67,7 @@ const sRenderMapState& CSubDlgRenderMap::GetRenderState() const
 
 void CSubDlgRenderMap::InvalidateFrame()
 {
-	CRect rc{ Ui::GetClientRect(this) };
-	m_frame.InvalidateRect(rc);
+	m_frame.InvalidateRect(nullptr, 0);
 }
 
 // Internal implementation

--- a/src/libs/ff1-subeditors/DlgPopoutMap.cpp
+++ b/src/libs/ff1-subeditors/DlgPopoutMap.cpp
@@ -7,6 +7,7 @@
 #include "afxdialogex.h"
 #include "IMapEditor.h"
 #include <FFBaseApp.h>
+#include <ff1.colors.h>
 #include <ui_helpers.h>
 #include <algorithm>
 #include <afxglobals.h>
@@ -92,6 +93,12 @@ BOOL CDlgPopoutMap::CreateModeless(IMapEditor* editor, CSize mapdims, CSize tile
 void CDlgPopoutMap::UpdateControls()
 {
 	update_tool_index();
+}
+
+void CDlgPopoutMap::InvalidateMap()
+{
+	auto rcdisp = GetDisplayArea();
+	InvalidateRect(rcdisp, 0);
 }
 
 void CDlgPopoutMap::ScrollByPercentage(int nBar, int percent)
@@ -440,7 +447,7 @@ void CDlgPopoutMap::OnPaint()
 	compat.FillSolidRect(client, RGB(255, 255, 255));
 	auto scrolloff = get_scroll_pos();
 	CRect drawrect = { 0, 0, displayarea.Width(), displayarea.Height() };
-	Editor->RenderMapEx(compat, drawrect, scrolloff, Tilesize);
+	Editor->RenderMapEx(compat, displayarea, scrolloff, Tilesize);
 
 	// Draw the bitmap to the window's display area.
 	// To ensure we only draw to that area, set it as the clip region.
@@ -458,7 +465,7 @@ void CDlgPopoutMap::OnPaint()
 
 	//TODO - might remove this frame border
 	displayarea.InflateRect(1, 1);
-	dc.Draw3dRect(displayarea, RGB(0, 0, 0), RGB(0, 0, 0));
+	dc.Draw3dRect(displayarea, COLOR_GRAY, COLOR_GRAY);
 
 	auto rc = get_sizer_rect(true);
 	dc.DrawFrameControl(rc, DFC_SCROLL, DFCS_SCROLLSIZEGRIP);

--- a/src/libs/ff1-subeditors/DlgPopoutMap.h
+++ b/src/libs/ff1-subeditors/DlgPopoutMap.h
@@ -20,6 +20,8 @@ public:
 	BOOL CreateModeless(IMapEditor* editor, CSize mapdims, CSize tiledims, CWnd* parent = nullptr);
 	bool SetButtons(const std::vector<sMapDlgButton>& buttons);
 	void UpdateControls();
+	void InvalidateMap();
+
 	void ScrollByPercentage(int nBar, int percent);
 	void ScrollToPos(int nBar, int mappos, bool center);
 

--- a/src/libs/ff1-utils/ff1.colors.h
+++ b/src/libs/ff1-utils/ff1.colors.h
@@ -1,10 +1,17 @@
 #pragma once
 
 #include <afxwin.h> // sigh, WinGdi.h is needed for RGB, but it needs BYTE from other headers, etc.
+//TODO - better off specifying these as 24-bit hex values?
 
 constexpr auto COLOR_BLACK = RGB(0, 0, 0);
-constexpr auto COLOR_GREEN = RGB(32, 192, 32);
-constexpr auto COLOR_ORANGE = RGB(255, 224, 32);
+constexpr auto COLOR_WHITE = RGB(255, 255, 255);
+constexpr auto COLOR_GRAY = RGB(128, 128, 128);
+constexpr auto COLOR_LTGRAY = RGB(192, 192, 192);
+constexpr auto COLOR_RED = RGB(255, 0, 0);
+constexpr auto COLOR_GREEN = RGB(0, 255, 0);
+constexpr auto COLOR_BLUE = RGB(0, 0, 255);
 constexpr auto COLOR_FFRED = RGB(160, 0, 0);
+constexpr auto COLOR_FFGREEN = RGB(32, 192, 32);
 constexpr auto COLOR_FFBLUE = RGB(32, 64, 255);
+constexpr auto COLOR_ORANGE = RGB(255, 224, 32);
 


### PR DESCRIPTION
Both maps should now refresh when toggling Last Click, Show rooms, Domain grid.
Also, slight update to pass the display area rect (instead of a 0-origin client rect) to CWoverworldMap's paint handler.
We can get the client rect from the display area rect and it allows us to handle something with the mouse.
- Domain labels now have a translucent label behind the =m to help with visibility.
- Domain labels temporarily hide if drawing under them.