### PR TITLE
Publish Path not being respected by Edit ROM or Create Project

### DIFF
--- a/src/apps/FFHacksterEx/FFHacksterDlg.cpp
+++ b/src/apps/FFHacksterEx/FFHacksterDlg.cpp
@@ -1017,7 +1017,14 @@ void CFFHacksterDlg::OnRevertProject()
 void CFFHacksterDlg::OnPublishProject()
 {
 	CString msg;
-	if (m_proj.Publish()) {
+	if (m_proj.PublishRomPath.IsEmpty()) {
+		AfxMessageBox("Please specify a Publish path first in Project Settings.", MB_ICONWARNING);
+	}
+	else if (!Paths::FileExists(m_proj.WorkRomPath)) {
+		CString comment = m_proj.IsAsm() ? "\nTry compiling the project first." : "";
+		AfxMessageBox("No working file file exists to export." + comment, MB_ICONWARNING);
+	}
+	else if (m_proj.Publish()) {
 		msg.Format("Successfully published working ROM to\n'%s'.", (LPCSTR)m_proj.PublishRomPath);
 		AfxMessageBox(msg);
 	}

--- a/src/libs/ff1-coredefs/FFHacksterProject.cpp
+++ b/src/libs/ff1-coredefs/FFHacksterProject.cpp
@@ -681,7 +681,7 @@ pair_result<CString> CFFHacksterProject::RevertValues()
 	Io::MakeWritable(destfile);
 
 	// If a temp file is being used, update that as well.
-	auto tempfile = this->ValuesPath;
+	const auto & tempfile = this->ValuesPath;
 	if (tempfile != destfile) {
 		if (!Paths::FileCopy(srcfile, tempfile))
 			THROWEXCEPTION(std::runtime_error,
@@ -714,9 +714,9 @@ bool CFFHacksterProject::UpdateVarsAndConstants()
 {
 	if (IsRom()) {
 		auto groups = mfcstrvec(ReadIni(ValuesPath, "ROMINIT_VARNAMES_SECTIONS", "value", ""));
-		for (auto group : groups) {
+		for (const auto & group : groups) {
 			auto names = mfcstrvec(ReadIni(ValuesPath, group, "value", ""));
-			for (auto name : names) {
+			for (const auto & name : names) {
 				auto value = ReadIni(ValuesPath, name, "value", "");
 				if (value.IsEmpty())
 					THROWEXCEPTION(std::runtime_error, "Value '" + std::string((LPCSTR)name) + "' is either missing or has an empty value property.");
@@ -912,7 +912,7 @@ bool CFFHacksterProject::RenameProjectFiles(CString projectpath, CString project
 			if (oldvalue.IsEmpty() || oldvalue.Find(srctitle) == -1) return;
 
 			//DEVNOTE - don't call Paths::ReplaceFileTitle here; it doesn't handle multi-dot extensions well in this case.
-			auto newvalue = oldvalue;
+			CString newvalue = oldvalue;
 			newvalue.Replace(srctitle, desttitle);
 			WriteIni(ini, section, key, newvalue);
 		};

--- a/src/libs/ff1-coredefs/path_functions.cpp
+++ b/src/libs/ff1-coredefs/path_functions.cpp
@@ -163,7 +163,7 @@ namespace Paths
 
 		auto files = GetFiles(source, GetFilesScope::NotRecursive);
 		size_t copycount = 0;
-		for (auto file : files) {
+		for (const auto & file : files) {
 			if (FileCopyTo(file, dest))
 				++copycount;
 		}
@@ -186,7 +186,7 @@ namespace Paths
 		if (!IsDir(source)) return false;
 
 		auto files = GetFiles(source, GetFilesScope::NotRecursive);
-		for (auto file : files) {
+		for (const auto & file : files) {
 			auto destfile = Paths::ReplacePath(file, dest);
 			std::error_code ec;
 			if (!fsys::copy_file((LPCSTR)file, (LPCSTR)destfile, fsys::copy_options::update_existing, ec)) {
@@ -259,7 +259,7 @@ namespace Paths
 	CString Combine(std::initializer_list<CString> parts)
 	{
 		fsys::path fpath;
-		for (auto part : parts)
+		for (const auto & part : parts)
 			fpath.append((LPCSTR)part);
 		return CString(fpath.u8string().c_str());
 	}
@@ -358,7 +358,7 @@ namespace Paths
 			// Find the files matching the filter in this folder
 			if (!filters.IsEmpty()) {
 				auto thefilters = Strings::split(filters, ";");
-				for (auto filter : thefilters) {
+				for (const auto & filter : thefilters) {
 					intptr_t hspecific = _findfirst(Paths::Combine({ folder, filter }), &c_file);
 					if (hspecific != -1L) {
 						do {
@@ -478,7 +478,7 @@ namespace Paths
 		if (fullpath[0] == '*') {
 			auto last = fullpath.ReverseFind('/');
 			last = (last != -1) ? last : fullpath.ReverseFind('\\');			
-			auto dir = (last == -1) ? fullpath : fullpath.Mid(0, last);
+			CString dir = (last == -1) ? fullpath : fullpath.Mid(0, last);
 			return dir;
 		}
 
@@ -679,7 +679,7 @@ namespace Paths
 		auto stem = origpath.GetLength() > 1 ? origpath.Mid(1) : "";
 		if (stem.GetLength() > 0 && (stem[0] == '/' || stem[0] == '\\'))
 			stem = stem.Mid(1);
-		auto temp = Paths::Combine({ base,  stem });
+		CString temp = Paths::Combine({ base,  stem });
 		auto newp = fsys::path((LPCSTR)temp);
 		//auto final = fsys::weakly_canonical(newp); //VISTA+
 		//return CString(final.u8string().c_str());
@@ -756,7 +756,7 @@ namespace Urls
 	{
 		CString out;
 		bool notfirst = false;
-		for (auto part : parts) {
+		for (const auto & part : parts) {
 			out.Append(notfirst ? "/" : "");
 			out.Append(part);
 			notfirst = true;
@@ -769,7 +769,7 @@ namespace Urls
 		if (filepath.Find("file:///") == 0) return filepath;
 
 		// Prefix the protocol and change back slashes to forward.
-		auto result = filepath;
+		CString result = filepath;
 		result.Replace("\\", "/");
 		return "file:///" + result;
 	}


### PR DESCRIPTION
The publish path should now be used when Edit ROM or Create Project have completed.
The path will be visible in the Project Settings folder.
In the project file, a path in the project folder uses the *PRJ* notation for the project folder.
Also, slight clarification of error messages when publishing.