### PR TITLE
Update owner draw check and radio message handling

### DIFF
--- a/src/libs/ff1-editors/Attack.h
+++ b/src/libs/ff1-editors/Attack.h
@@ -34,10 +34,10 @@ protected:
 // Dialog Data
 	enum { IDD = IDD_ATTACK };
 
-	CClearButton	m_eff_effect;
-	CClearButton	m_eff_damage;
+	CClearRadio	m_eff_effect;
+	CClearRadio	m_eff_damage;
 	CClearEdit	m_unknown;
-	CClearButton	m_target;
+	CClearCheck	m_target;
 	CStrikeCheck	m_elem8;
 	CStrikeCheck	m_elem7;
 	CStrikeCheck	m_elem6;

--- a/src/libs/ff1-utils/ClearButton.cpp
+++ b/src/libs/ff1-utils/ClearButton.cpp
@@ -389,22 +389,12 @@ void CClearButton::PreSubclassWindow()
 
 BOOL CClearButton::PreTranslateMessage(MSG* pMsg)
 {
-	switch (pMsg->message) {
-	case WM_KEYDOWN:
+	if (pMsg->message == WM_KEYDOWN) {
 		if (pMsg->wParam == VK_RETURN) {
-			::DispatchMessage(pMsg);
-			auto pdlg = DYNAMIC_DOWNCAST(CDialog, GetParent());
-			auto defid = (pdlg != nullptr) ? pdlg->GetDefID() : 0;
-
-			// avoid the dozen reserved dialog control IDs (IDOK, etc.)
-			auto pctl = defid > 12 ? pdlg->GetDlgItem(defid) : nullptr;
-			if (defid > 0)
-				pdlg->PostMessage(WM_COMMAND, MAKEWPARAM(defid, BN_CLICKED), (LPARAM)pctl);
-			return true;
+			SendBnClickedToParent(this);
+			return TRUE;
 		}
-		break;
 	}
-
 	return CButton::PreTranslateMessage(pMsg);
 }
 

--- a/src/libs/ff1-utils/ClearCheckBox.cpp
+++ b/src/libs/ff1-utils/ClearCheckBox.cpp
@@ -1,0 +1,45 @@
+// ClearCheckBox.cpp : implementation file
+//
+
+#include "stdafx.h"
+#include "ClearCheckBox.h"
+
+
+// CClearCheckBox
+
+IMPLEMENT_DYNAMIC(CClearCheckBox, CButton)
+
+CClearCheckBox::CClearCheckBox()
+{
+}
+
+CClearCheckBox::~CClearCheckBox()
+{
+}
+
+
+BEGIN_MESSAGE_MAP(CClearCheckBox, CButton)
+END_MESSAGE_MAP()
+
+
+// CClearCheckBox message handlers
+
+BOOL CClearCheckBox::PreTranslateMessage(MSG* pMsg)
+{
+	switch (pMsg->message) {
+	case WM_KEYDOWN:
+		if (pMsg->wParam == VK_RETURN) {
+			::DispatchMessage(pMsg);
+			auto pdlg = DYNAMIC_DOWNCAST(CDialog, GetParent());
+			auto defid = (pdlg != nullptr) ? pdlg->GetDefID() : 0;
+
+			// avoid the dozen reserved dialog control IDs (IDOK, etc.)
+			auto pctl = defid > 12 ? pdlg->GetDlgItem(defid) : nullptr;
+			if (defid > 0)
+				pdlg->PostMessage(WM_COMMAND, MAKEWPARAM(defid, BN_CLICKED), (LPARAM)pctl);
+			return true;
+		}
+		break;
+	}
+	return CButton::PreTranslateMessage(pMsg);
+}

--- a/src/libs/ff1-utils/ClearCheckBox.h
+++ b/src/libs/ff1-utils/ClearCheckBox.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "ClearButton.h"
+
+// CClearCheckBox
+
+class CClearCheckBox : public CButton
+{
+	DECLARE_DYNAMIC(CClearCheckBox)
+
+public:
+	CClearCheckBox();
+	virtual ~CClearCheckBox();
+
+protected:
+	DECLARE_MESSAGE_MAP()
+
+	virtual BOOL PreTranslateMessage(MSG* pMsg);
+};
+
+using CClearCheck = CClearCheckBox;

--- a/src/libs/ff1-utils/ClearRadio.cpp
+++ b/src/libs/ff1-utils/ClearRadio.cpp
@@ -1,0 +1,45 @@
+// ClearRadio.cpp : implementation file
+//
+
+#include "stdafx.h"
+#include "ClearRadio.h"
+
+
+// CClearRadio
+
+IMPLEMENT_DYNAMIC(CClearRadio, CButton)
+
+CClearRadio::CClearRadio()
+{
+}
+
+CClearRadio::~CClearRadio()
+{
+}
+
+
+BEGIN_MESSAGE_MAP(CClearRadio, CButton)
+END_MESSAGE_MAP()
+
+
+// CClearRadio message handlers
+
+BOOL CClearRadio::PreTranslateMessage(MSG* pMsg)
+{
+	switch (pMsg->message) {
+	case WM_KEYDOWN:
+		if (pMsg->wParam == VK_RETURN) {
+			::DispatchMessage(pMsg);
+			auto pdlg = DYNAMIC_DOWNCAST(CDialog, GetParent());
+			auto defid = (pdlg != nullptr) ? pdlg->GetDefID() : 0;
+
+			// avoid the dozen reserved dialog control IDs (IDOK, etc.)
+			auto pctl = defid > 12 ? pdlg->GetDlgItem(defid) : nullptr;
+			if (defid > 0)
+				pdlg->PostMessage(WM_COMMAND, MAKEWPARAM(defid, BN_CLICKED), (LPARAM)pctl);
+			return true;
+		}
+		break;
+	}
+	return CButton::PreTranslateMessage(pMsg);
+}

--- a/src/libs/ff1-utils/ClearRadio.h
+++ b/src/libs/ff1-utils/ClearRadio.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "ClearButton.h"
+
+// CClearRadio
+
+class CClearRadio : public CClearButton
+{
+	DECLARE_DYNAMIC(CClearRadio)
+
+public:
+	CClearRadio();
+	virtual ~CClearRadio();
+
+protected:
+	DECLARE_MESSAGE_MAP()
+
+	virtual BOOL PreTranslateMessage(MSG* pMsg);
+};

--- a/src/libs/ff1-utils/StrikeCheck.cpp
+++ b/src/libs/ff1-utils/StrikeCheck.cpp
@@ -265,5 +265,20 @@ LRESULT CStrikeCheck::OnGetCheck(WPARAM wparam, LPARAM lparam)
 
 BOOL CStrikeCheck::PreTranslateMessage(MSG* pMsg)
 {
+	switch (pMsg->message) {
+	case WM_KEYDOWN:
+		if (pMsg->wParam == VK_RETURN) {
+			::DispatchMessage(pMsg);
+			auto pdlg = DYNAMIC_DOWNCAST(CDialog, GetParent());
+			auto defid = (pdlg != nullptr) ? pdlg->GetDefID() : 0;
+
+			// avoid the dozen reserved dialog control IDs (IDOK, etc.)
+			auto pctl = defid > 12 ? pdlg->GetDlgItem(defid) : nullptr;
+			if (defid > 0)
+				pdlg->PostMessage(WM_COMMAND, MAKEWPARAM(defid, BN_CLICKED), (LPARAM)pctl);
+			return true;
+		}
+		break;
+	}
 	return CClearButton::PreTranslateMessage(pMsg);
 }

--- a/src/libs/ff1-utils/StrikeCheck.h
+++ b/src/libs/ff1-utils/StrikeCheck.h
@@ -32,6 +32,7 @@ protected:
 
 	virtual void DrawItem(LPDRAWITEMSTRUCT pdi);
 	virtual void PreSubclassWindow();
+	virtual BOOL PreTranslateMessage(MSG* pMsg);
 
 	DECLARE_MESSAGE_MAP()
 	afx_msg void OnLButtonUp(UINT nFlags, CPoint point);
@@ -41,6 +42,4 @@ protected:
 	afx_msg void OnKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags);
 	afx_msg LRESULT OnSetCheck(WPARAM wparam, LPARAM lparam);
 	afx_msg LRESULT OnGetCheck(WPARAM wparam, LPARAM lparam);
-public:
-	virtual BOOL PreTranslateMessage(MSG* pMsg);
 };

--- a/src/libs/ff1-utils/ff1-utils-controls.h
+++ b/src/libs/ff1-utils/ff1-utils-controls.h
@@ -7,6 +7,9 @@
 
 #include "ClearButton.h"
 
+#include "ClearCheckBox.h"
+#include "ClearRadio.h"
+
 #include "BorderedEdit.h"
 #include "ClearEdit.h"
 #include "InplaceEdit.h"

--- a/src/libs/ff1-utils/ff1-utils.vcxproj
+++ b/src/libs/ff1-utils/ff1-utils.vcxproj
@@ -176,6 +176,8 @@
     <ClInclude Include="BorderedListCtrl.h" />
     <ClInclude Include="BorderedListBox.h" />
     <ClInclude Include="BrowseForFolderDialog.h" />
+    <ClInclude Include="ClearCheckBox.h" />
+    <ClInclude Include="ClearRadio.h" />
     <ClInclude Include="OffscreenDC.h" />
     <ClInclude Include="SimpleImageButton.h" />
     <ClInclude Include="DlgPickDestinationFile.h" />
@@ -233,6 +235,8 @@
     <ClCompile Include="BorderedListCtrl.cpp" />
     <ClCompile Include="BorderedListBox.cpp" />
     <ClCompile Include="BrowseForFolderDialog.cpp" />
+    <ClCompile Include="ClearCheckBox.cpp" />
+    <ClCompile Include="ClearRadio.cpp" />
     <ClCompile Include="OffscreenDC.cpp" />
     <ClCompile Include="SimpleImageButton.cpp" />
     <ClCompile Include="DlgPickDestinationFile.cpp" />

--- a/src/libs/ff1-utils/ff1-utils.vcxproj.filters
+++ b/src/libs/ff1-utils/ff1-utils.vcxproj.filters
@@ -183,6 +183,12 @@
     <ClInclude Include="SubEditDialogEx.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="ClearCheckBox.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ClearRadio.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -333,6 +339,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="SubEditDialogEx.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ClearCheckBox.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ClearRadio.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Owner draw checks and radios have additional handling for the default command on a dialog.
The Owner draw button CClearButton was reverted to its previous handler.