### PR TITLE
Armor editor copy swap

### DIFF
--- a/src/libs/ff1-coredefs/ff1-coredefs.vcxproj.filters
+++ b/src/libs/ff1-coredefs/ff1-coredefs.vcxproj.filters
@@ -7,8 +7,9 @@
     </Filter>
     <Filter Include="Header Files">
       <UniqueIdentifier>{64557154-9132-4855-869e-ec44424d4afe}</UniqueIdentifier>
+      <Extensions>h;hpp</Extensions>
     </Filter>
-    <Filter Include="Header Files\Resource Files">
+    <Filter Include="Resource Files">
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
@@ -125,33 +126,33 @@
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="ff1-coredefs.rc">
-      <Filter>Header Files\Resource Files</Filter>
+      <Filter>Resource Files</Filter>
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
     <Image Include="res\iconmonstr-x-mark-2-24.png">
-      <Filter>Header Files\Resource Files</Filter>
+      <Filter>Resource Files</Filter>
     </Image>
     <Image Include="res\drawingtools.bmp">
-      <Filter>Header Files\Resource Files</Filter>
+      <Filter>Resource Files</Filter>
     </Image>
     <Image Include="res\advdrawi.bmp">
-      <Filter>Header Files\Resource Files</Filter>
+      <Filter>Resource Files</Filter>
     </Image>
     <Image Include="res\iconmonstr-minus-2-24.png">
-      <Filter>Header Files\Resource Files</Filter>
+      <Filter>Resource Files</Filter>
     </Image>
     <Image Include="res\iconmonstr-help-1-24.png">
-      <Filter>Header Files\Resource Files</Filter>
+      <Filter>Resource Files</Filter>
     </Image>
     <Image Include="res\iconmonstr-info-6-24.png">
-      <Filter>Header Files\Resource Files</Filter>
+      <Filter>Resource Files</Filter>
     </Image>
     <Image Include="res\iconmonstr-gear-3-24.png">
-      <Filter>Header Files\Resource Files</Filter>
+      <Filter>Resource Files</Filter>
     </Image>
     <Image Include="res\iconmonstr-book-27-24.png">
-      <Filter>Header Files\Resource Files</Filter>
+      <Filter>Resource Files</Filter>
     </Image>
   </ItemGroup>
   <ItemGroup>

--- a/src/libs/ff1-editors/Armor.cpp
+++ b/src/libs/ff1-editors/Armor.cpp
@@ -290,7 +290,7 @@ void CArmor::StoreValues()
 void CArmor::HandleArmorListContextMenu(CWnd* pWnd, CPoint point)
 {
 	using namespace copypaste_helpers;
-	auto optionnames = mfcstringvector{ "Name", "Absorb", "Evade", "Spell", "Resist", "Price", "Equip", "Armor Type" };
+	auto optionnames = mfcstringvector{ "Name", "Evade", "Absorb", "Resist", "Spell", "Price", "Equip", "Armor Type" };
 	auto result = InvokeCopySwap(m_armorlist, point, m_selitem, optionnames);
 	switch (result.selcmd) {
 	case ID_FFH_COPY:

--- a/src/libs/ff1-editors/Armor.cpp
+++ b/src/libs/ff1-editors/Armor.cpp
@@ -315,61 +315,6 @@ void CArmor::HandleArmorListContextMenu(CWnd* pWnd, CPoint point)
 		if (!result.message.IsEmpty()) AfxMessageBox(result.message);
 		break;
 	}
-
-	//auto thisitem = Ui::ItemFromPoint(m_armorlist, point);
-	//if (thisitem == -1) return;
-
-	//CString thisname = Ui::GetItemText(m_armorlist, thisitem);
-	//CMenu menu;
-	//VERIFY(menu.CreatePopupMenu());
-	//menu.AppendMenu(MF_BYCOMMAND, ID_FFH_COPY, copypaste_helpers::BuildCopyPasteText(ID_FFH_COPY, thisname, ""));
-	//if (m_selitem != -1 && m_selitem != thisitem) {
-	//	CString selname = Ui::GetItemText(m_armorlist, m_selitem);
-	//	menu.AppendMenu(MF_BYCOMMAND, ID_FFH_PASTE, copypaste_helpers::BuildCopyPasteText(ID_FFH_PASTE, selname, thisname));
-	//	menu.AppendMenu(MF_BYCOMMAND, ID_FFH_SWAP, copypaste_helpers::BuildCopyPasteText(ID_FFH_SWAP, selname, thisname));
-	//}
-	//auto selcmd = menu.TrackPopupMenu(TPM_RETURNCMD | TPM_LEFTALIGN, point.x, point.y, pWnd);
-	//switch(selcmd) {
-	//case ID_FFH_COPY:
-	//	m_selitem = thisitem;
-	//	break;
-	//case ID_FFH_PASTE: 
-	//case ID_FFH_SWAP:
-	//{
-	//	std::vector<PasteTarget> options = {
-	//		{ "Name", false },
-	//		{ "Absorb", false },
-	//		{ "Evade", false },
-	//		{ "Spell", false },
-	//		{ "Resist", false },
-	//		{ "Price", false },
-	//		{ "Equip", false },
-	//		{ "Armor Type", false },
-	//	};
-	//	CDlgPasteTargets dlgtargets(this);
-	//	menu.GetMenuString(selcmd, dlgtargets.Title, MF_BYCOMMAND);
-	//	dlgtargets.SetTargets(options);
-	//	if (dlgtargets.DoModal() == IDOK) {
-	//		if (dlgtargets.IsAnyChecked()) {
-	//			bool swap = selcmd == ID_FFH_SWAP;
-	//			auto flags = dlgtargets.GetResults();
-
-	//			using namespace copypaste_helpers;
-	//			CopySwapBytes(swap, Project->ROM, m_selitem, thisitem, ARMOR_OFFSET, ARMOR_BYTES, 0,
-	//				{ flags[1], flags[2], flags[3], flags[4] });
-	//			if (flags[0]) DoCopySwapName(swap, m_selitem, thisitem);
-	//			if (flags[5]) CopySwapBuffer(swap, Project->ROM, m_selitem, thisitem, ARMORPRICE_OFFSET, 2, 0, 2);
-	//			if (flags[6]) CopySwapBuffer(swap, Project->ROM, m_selitem, thisitem, ARMORPERMISSIONS_OFFSET, 2, 0, 2);
-	//			if (flags[7]) CopySwapBuffer(swap, Project->ROM, m_selitem, thisitem, ARMORTYPE_OFFSET, 1, 0, 1);
-	//			LoadValues();
-	//		}
-	//		else {
-	//			AfxMessageBox("You must select at least one item for paste/swap to have an effect.");
-	//		}
-	//	}
-	//	break;
-	//}
-	//}
 }
 
 void CArmor::DoCopySwapName(bool swap, int srcitem, int dstitem)

--- a/src/libs/ff1-editors/Armor.h
+++ b/src/libs/ff1-editors/Armor.h
@@ -16,11 +16,16 @@ public:
 	int cur;
 
 protected:
+	int m_selitem = -1;
+
 	virtual void LoadOffsets();
 	virtual void LoadRom();
 	virtual void SaveRom();
 	virtual void LoadValues();
 	virtual void StoreValues();
+
+	void HandleArmorListContextMenu(CWnd* pWnd, CPoint point);
+	void DoCopySwapName(bool swap, int srcitem, int dstitem);
 
 // Dialog Data
 	enum { IDD = IDD_ARMOR };
@@ -89,4 +94,5 @@ protected:
 	DECLARE_MESSAGE_MAP()
 
 	afx_msg void OnSelchangeArmorlist();
+	afx_msg void OnContextMenu(CWnd* pWnd, CPoint point);
 };

--- a/src/libs/ff1-subeditors/DlgPasteTargets.cpp
+++ b/src/libs/ff1-subeditors/DlgPasteTargets.cpp
@@ -6,6 +6,7 @@
 #include "afxdialogex.h"
 #include "imaging_helpers.h"
 #include "ui_helpers.h"
+#include <algorithm>
 
 using namespace Imaging;
 using namespace Ui;
@@ -28,9 +29,19 @@ void CDlgPasteTargets::SetTargets(const std::vector<PasteTarget>& targets)
 	m_targets = targets;
 }
 
+bool CDlgPasteTargets::IsAnyChecked() const
+{
+	return std::any_of(cbegin(m_checked), cend(m_checked), [](auto c) { return c == true; });
+}
+
 bool CDlgPasteTargets::IsChecked(int index) const
 {
 	return index < (int)m_checked.size() ? m_checked[index] : false;
+}
+
+std::vector<bool> CDlgPasteTargets::GetResults() const
+{
+	return m_checked;
 }
 
 std::vector<CButton*> CDlgPasteTargets::GetChecks()

--- a/src/libs/ff1-subeditors/DlgPasteTargets.h
+++ b/src/libs/ff1-subeditors/DlgPasteTargets.h
@@ -4,13 +4,7 @@
 #include <vector>
 #include "afxwin.h"
 #include <FFBaseDlg.h>
-
-struct PasteTarget
-{
-	CString caption;
-	bool checked;
-	CString warning;
-};
+#include <copypaste_helpers.h>
 
 // CDlgPasteTargets dialog
 
@@ -24,7 +18,9 @@ public:
 
 	CString Title;
 	void SetTargets(const std::vector<PasteTarget> & targets);
+	bool IsAnyChecked() const;
 	bool IsChecked(int index) const;
+	std::vector<bool> GetResults() const;
 
 // Dialog Data
 #ifdef AFX_DESIGN_TIME
@@ -42,6 +38,7 @@ protected:
 
 	CToolTipCtrl m_tooltips;
 	CButton m_pastetarget1;
+	CButton m_checkall;
 
 	DECLARE_MESSAGE_MAP()
 	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
@@ -49,8 +46,5 @@ protected:
 	virtual void OnOK();
 	virtual BOOL PreTranslateMessage(MSG* pMsg);
 	afx_msg void OnDestroy();
-public:
 	afx_msg void OnBnClickedCheckAll();
-protected:
-	CButton m_checkall;
 };

--- a/src/libs/ff1-subeditors/copypaste_helpers.cpp
+++ b/src/libs/ff1-subeditors/copypaste_helpers.cpp
@@ -1,0 +1,167 @@
+#include "stdafx.h"
+#include "copypaste_helpers.h"
+#include <ui_helpers.h>
+#include "DlgPasteTargets.h"
+#include <algorithm>
+
+namespace copypaste_helpers
+{
+
+	CString BuildCopyPasteText(int flag, CString srcname, CString destname)
+	{
+		CString cs;
+		switch (flag) {
+		case ID_FFH_COPY:
+			cs.Format("&Copy %s", (LPCSTR)srcname);
+			break;
+		case ID_FFH_PASTE:
+			cs.Format("Paste from %s to %s", (LPCSTR)srcname, (LPCSTR)destname);
+			break;
+		case ID_FFH_SWAP:
+			cs.Format("Swap %s with %s", (LPCSTR)srcname, (LPCSTR)destname);
+			break;
+		default:
+			cs.Format("Unknown operation '%d'", flag);
+			throw std::runtime_error((LPCSTR)cs);
+			break;
+		}
+		return cs;
+	}
+
+	void CopySwapBytes(bool swap, std::vector<unsigned char>& rom, int srcindex, int dstindex,
+		int baseoffset, int recwidth, int start, std::vector<bool> flags)
+	{
+		int srcoffset = baseoffset + (srcindex * recwidth);
+		int destoffset = baseoffset + (dstindex * recwidth);
+		size_t bytecount = flags.size();
+		for (size_t i = start, end = start + bytecount; i < end; ++i) {
+			if (!flags[i])
+				continue;
+
+			auto src = srcoffset + i;
+			auto dst = destoffset + i;
+			if (swap) {
+				auto temp = rom[dst];
+				rom[dst] = rom[src];
+				rom[src] = temp;
+			}
+			else {
+				rom[dst] = rom[src];
+			}
+		}
+	}
+
+	void CopySwapBuffer(bool swap, std::vector<unsigned char>& rom, int srcindex, int dstindex,
+		int baseoffset, int recwidth, int start, int bytecount)
+	{
+		int srcoffset = baseoffset + (srcindex * recwidth);
+		int destoffset = baseoffset + (dstindex * recwidth);
+		for (int i = start, end = start + bytecount; i < end; ++i) {
+			auto src = srcoffset + i;
+			auto dst = destoffset + i;
+			if (swap) {
+				auto temp = rom[dst];
+				rom[dst] = rom[src];
+				rom[src] = temp;
+			}
+			else {
+				rom[dst] = rom[src];
+			}
+		}
+	}
+
+	void CopySwapPermissions(bool swap, std::vector<unsigned char>& rom, size_t srcindex, size_t destindex,
+		size_t baseoffset, size_t bits, size_t start, size_t count)
+	{
+		const unsigned short valuemask = (1 << bits) - 1;
+		const unsigned short srcmask = (1 << ((bits - 1) - srcindex));
+		const unsigned short dstmask = (1 << ((bits - 1) - destindex));
+		const size_t step = bits > 8 ? 2 : 1; // handles lists of BYTEs and WORDs
+
+		for (size_t i = start, end = start + count; i < end; ++i) {
+			size_t offset = baseoffset + (i * step);
+			unsigned short origoctet = rom[offset];
+			unsigned short octet = rom[offset] + (rom[offset + 1] << 8);
+
+			// I invert the byte to make it a little more intuitive.
+			// So now, the class can use the item if the bit is SET.
+			auto invoct = (unsigned short)(~octet & valuemask);
+
+			// Set dest if source is set, clear it otherwise
+			bool srcon = (octet & srcmask) != srcmask;
+			unsigned short newdst = srcon ? dstmask : 0;
+
+			if (swap) {
+				// We're swapping, so get the bit states,
+				// then swap them and OR the swapped states back into invoct.
+				bool dston = (octet & dstmask) != dstmask;
+				unsigned short newsrc = dston ? srcmask : 0;
+				invoct &= ~(srcmask | dstmask);
+				invoct |= (newsrc | newdst);
+			}
+			else {
+				// We're copying, so if the source bit was set,
+				// turn on the dest mask bit; otherwise turn it off.
+				invoct &= ~dstmask;
+				invoct |= newdst;
+			}
+
+			// Reverse the inversion and store the change
+			auto newoctet = (unsigned short)(~invoct & valuemask);
+			rom[offset] = newoctet & 0xFF;
+			if (bits > 8) rom[offset + 1] = (newoctet >> 8) & 0xFF;
+		}
+	}
+
+	sCopySwapResult InvokeCopySwap(CListBox& wnd, CPoint point, int selitem, std::vector<CString> optionnames)
+	{
+		std::vector<PasteTarget> options(optionnames.size());
+		std::transform(cbegin(optionnames), cend(optionnames), begin(options), [](auto name) -> PasteTarget { return {name,false}; });
+		return InvokeCopySwap(wnd, point, selitem, options);
+	}
+
+	sCopySwapResult InvokeCopySwap(CListBox& wnd, CPoint point, int selitem, std::vector<PasteTarget> options)
+	{
+		sCopySwapResult result;
+		auto thisitem = Ui::ItemFromPoint(wnd, point);
+		if (thisitem == -1) return result;
+
+		result.thisindex = thisitem;
+
+		CString thisname = Ui::GetItemText(wnd, thisitem);
+		CMenu menu;
+		VERIFY(menu.CreatePopupMenu());
+		menu.AppendMenu(MF_BYCOMMAND, ID_FFH_COPY, copypaste_helpers::BuildCopyPasteText(ID_FFH_COPY, thisname, ""));
+		if (selitem != -1 && selitem != thisitem) {
+			CString selname = Ui::GetItemText(wnd, selitem);
+			menu.AppendMenu(MF_BYCOMMAND, ID_FFH_PASTE, copypaste_helpers::BuildCopyPasteText(ID_FFH_PASTE, selname, thisname));
+			menu.AppendMenu(MF_BYCOMMAND, ID_FFH_SWAP, copypaste_helpers::BuildCopyPasteText(ID_FFH_SWAP, selname, thisname));
+		}
+		auto selcmd = menu.TrackPopupMenu(TPM_RETURNCMD | TPM_LEFTALIGN, point.x, point.y, &wnd);
+		switch (selcmd) {
+		case ID_FFH_COPY:
+			result.selcmd = selcmd;
+			result.copyindex = thisitem;
+			break;
+		case ID_FFH_PASTE:
+		case ID_FFH_SWAP:
+		{
+			CDlgPasteTargets dlgtargets(wnd.GetParent());
+			menu.GetMenuString(selcmd, dlgtargets.Title, MF_BYCOMMAND);
+			dlgtargets.SetTargets(options);
+			if (dlgtargets.DoModal() == IDOK) {
+				if (dlgtargets.IsAnyChecked()) {
+					result.selcmd = selcmd;
+					result.flags = dlgtargets.GetResults();
+				}
+				else {
+					result.message = "You must select at least one item for paste/swap to have an effect.";
+				}
+			}
+			break;
+		}
+		}
+		return result;
+	}
+
+} // end namespace

--- a/src/libs/ff1-subeditors/copypaste_helpers.h
+++ b/src/libs/ff1-subeditors/copypaste_helpers.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <vector>
+
+#define ID_FFH_NOCOPYSWAP  0
+#define ID_FFH_COPY        ID_EDIT_COPY
+#define ID_FFH_PASTE       ID_EDIT_PASTE
+#define ID_FFH_SWAP        ID_EDIT_REPLACE
+
+struct PasteTarget
+{
+	CString caption;
+	bool checked;
+	CString warning;
+};
+
+namespace copypaste_helpers
+{
+	CString BuildCopyPasteText(int flag, CString srcname, CString destname);
+
+	void CopySwapBytes(bool swap, std::vector<unsigned char>& rom, int srcindex, int dstindex,
+		int baseoffset, int recwidth, int start, std::vector<bool> flags);
+	void CopySwapBuffer(bool swap, std::vector<unsigned char>& rom, int srcindex, int dstindex,
+		int baseoffset, int recwidth, int start, int bytecount);
+	void CopySwapPermissions(bool swap, std::vector<unsigned char>& rom, size_t srcindex, size_t destindex,
+		size_t baseoffset, size_t bits, size_t start, size_t count);
+
+	struct sCopySwapResult
+	{
+		int selcmd = ID_FFH_NOCOPYSWAP;
+		int thisindex = -1;
+		int copyindex = -1;
+		std::vector<bool> flags;
+		CString message;
+	};
+
+	sCopySwapResult InvokeCopySwap(CListBox& wnd, CPoint point, int selitem, std::vector<CString> optionnames);
+	sCopySwapResult InvokeCopySwap(CListBox& wnd, CPoint point, int selitem, std::vector<PasteTarget> options);
+};

--- a/src/libs/ff1-subeditors/ff1-subeditors.vcxproj
+++ b/src/libs/ff1-subeditors/ff1-subeditors.vcxproj
@@ -171,42 +171,11 @@
     <Text Include="ReadMe.txt" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Backdrop.h" />
-    <ClInclude Include="BattlePalettes.h" />
-    <ClInclude Include="BattlePatternTables.h" />
-    <ClInclude Include="BattlePic.h" />
-    <ClInclude Include="DlgPopoutMap.h" />
-    <ClInclude Include="CSubDlgRenderMap.h" />
-    <ClInclude Include="CSubDlgRenderMapStatic.h" />
-    <ClInclude Include="FloatingMapDlg.h" />
-    <ClInclude Include="DrawingToolButton.h" />
-    <ClInclude Include="Coords.h" />
-    <ClInclude Include="CustomTool.h" />
-    <ClInclude Include="DlgEditIniValue.h" />
-    <ClInclude Include="DlgEditScalars.h" />
-    <ClInclude Include="DlgEditStrings.h" />
-    <ClInclude Include="DlgPasteTargets.h" />
-    <ClInclude Include="ICoordMap.h" />
-    <ClInclude Include="IMapEditor.h" />
-    <ClInclude Include="InplaceArrayEdit.h" />
-    <ClInclude Include="Loading.h" />
-    <ClInclude Include="Mapman.h" />
-    <ClInclude Include="MiniMap.h" />
-    <ClInclude Include="NESPalette.h" />
-    <ClInclude Include="NewLabel.h" />
-    <ClInclude Include="resource_subeditors.h" />
-    <ClInclude Include="sRenderMapState.h" />
-    <ClInclude Include="stdafx.h" />
-    <ClInclude Include="targetver.h" />
-    <ClInclude Include="TileEdit.h" />
-    <ClInclude Include="Tint.h" />
-    <ClInclude Include="WepMagGraphic.h" />
-  </ItemGroup>
-  <ItemGroup>
     <ClCompile Include="Backdrop.cpp" />
     <ClCompile Include="BattlePalettes.cpp" />
     <ClCompile Include="BattlePatternTables.cpp" />
     <ClCompile Include="BattlePic.cpp" />
+    <ClCompile Include="copypaste_helpers.cpp" />
     <ClCompile Include="CSubDlgRenderMap.cpp" />
     <ClCompile Include="CSubDlgRenderMapStatic.cpp" />
     <ClCompile Include="FloatingMapDlg.cpp" />
@@ -259,6 +228,39 @@
     <Image Include="res\iconmonstr-tree-11-green-16.png" />
     <Image Include="res\iconmonstr-weather-94-16.png" />
     <Image Include="res\iconmonstr-weather-94-brown-16.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Backdrop.h" />
+    <ClInclude Include="BattlePalettes.h" />
+    <ClInclude Include="BattlePatternTables.h" />
+    <ClInclude Include="BattlePic.h" />
+    <ClInclude Include="Coords.h" />
+    <ClInclude Include="copypaste_helpers.h" />
+    <ClInclude Include="CSubDlgRenderMap.h" />
+    <ClInclude Include="CSubDlgRenderMapStatic.h" />
+    <ClInclude Include="CustomTool.h" />
+    <ClInclude Include="DlgEditIniValue.h" />
+    <ClInclude Include="DlgEditScalars.h" />
+    <ClInclude Include="DlgEditStrings.h" />
+    <ClInclude Include="DlgPasteTargets.h" />
+    <ClInclude Include="DlgPopoutMap.h" />
+    <ClInclude Include="DrawingToolButton.h" />
+    <ClInclude Include="FloatingMapDlg.h" />
+    <ClInclude Include="ICoordMap.h" />
+    <ClInclude Include="IMapEditor.h" />
+    <ClInclude Include="InplaceArrayEdit.h" />
+    <ClInclude Include="Loading.h" />
+    <ClInclude Include="Mapman.h" />
+    <ClInclude Include="MiniMap.h" />
+    <ClInclude Include="NESPalette.h" />
+    <ClInclude Include="NewLabel.h" />
+    <ClInclude Include="resource_subeditors.h" />
+    <ClInclude Include="sRenderMapState.h" />
+    <ClInclude Include="stdafx.h" />
+    <ClInclude Include="targetver.h" />
+    <ClInclude Include="TileEdit.h" />
+    <ClInclude Include="Tint.h" />
+    <ClInclude Include="WepMagGraphic.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/libs/ff1-subeditors/ff1-subeditors.vcxproj.filters
+++ b/src/libs/ff1-subeditors/ff1-subeditors.vcxproj.filters
@@ -5,109 +5,17 @@
       <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
       <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
     </Filter>
-    <Filter Include="Header Files">
-      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
-      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
-    </Filter>
     <Filter Include="Resource Files">
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{23f7b983-bd97-4a94-a423-3b2943e9edbe}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <Text Include="ReadMe.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="stdafx.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="targetver.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="CustomTool.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="BattlePic.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Mapman.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="NESPalette.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="NewLabel.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="WepMagGraphic.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Coords.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="ICoordMap.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Backdrop.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Loading.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="MiniMap.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="TileEdit.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Tint.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="BattlePalettes.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="BattlePatternTables.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="DlgEditScalars.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="DlgEditStrings.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="DlgEditIniValue.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="DlgPasteTargets.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="InplaceArrayEdit.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="resource_subeditors.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="DrawingToolButton.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="FloatingMapDlg.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="CSubDlgRenderMap.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="CSubDlgRenderMapStatic.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="sRenderMapState.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="IMapEditor.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="DlgPopoutMap.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -188,6 +96,9 @@
     <ClCompile Include="DlgPopoutMap.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="copypaste_helpers.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="ff1-subeditors.rc">
@@ -227,5 +138,100 @@
     <Image Include="res\iconmonstr-weather-94-brown-16.png">
       <Filter>Resource Files</Filter>
     </Image>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Backdrop.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="BattlePalettes.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="BattlePatternTables.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="BattlePic.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Coords.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="CSubDlgRenderMap.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="CSubDlgRenderMapStatic.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="CustomTool.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="DlgEditIniValue.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="DlgEditScalars.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="DlgEditStrings.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="DlgPasteTargets.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="DlgPopoutMap.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="DrawingToolButton.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="FloatingMapDlg.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ICoordMap.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IMapEditor.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="InplaceArrayEdit.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Loading.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Mapman.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="MiniMap.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="NESPalette.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="NewLabel.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="resource_subeditors.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="sRenderMapState.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="stdafx.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="targetver.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="TileEdit.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Tint.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="WepMagGraphic.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="copypaste_helpers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/src/libs/ff1-utils/ingame_text_functions.cpp
+++ b/src/libs/ff1-utils/ingame_text_functions.cpp
@@ -513,7 +513,7 @@ namespace Ingametext
 		return LoadExpandedOneBasedEntry(address(proj.ROM), index, WEAPONTEXT_OFFSET, BASICTEXT_PTRADD, proj.GetTable(1), showindex);
 	}
 
-	void DoPasteSwapStringBytes(bool swapping, CFFHacksterProject& proj, int context, int sourceindex, int destindex)
+	void PasteSwapStringBytes(bool swapping, CFFHacksterProject& proj, int context, int sourceindex, int destindex)
 	{
 		if (context == INTROTEXT) {
 			return; //TODO - or throw? it's not applicable here
@@ -580,12 +580,12 @@ namespace Ingametext
 
 	void SwapStringBytes(CFFHacksterProject& proj, int context, int sourceindex, int destindex)
 	{
-		DoPasteSwapStringBytes(true, proj, context, sourceindex, destindex);
+		PasteSwapStringBytes(true, proj, context, sourceindex, destindex);
 	}
 
 	void OverwriteStringBytes(CFFHacksterProject& proj, int context, int sourceindex, int destindex)
 	{
-		DoPasteSwapStringBytes(false, proj, context, sourceindex, destindex);
+		PasteSwapStringBytes(false, proj, context, sourceindex, destindex);
 	}
 
 } // end namespace Ingametext

--- a/src/libs/ff1-utils/ingame_text_functions.h
+++ b/src/libs/ff1-utils/ingame_text_functions.h
@@ -51,6 +51,7 @@ namespace Ingametext
 	dataintnode LoadPotionEntry(CFFHacksterProject & proj, int index, bool showindex = false);
 	dataintnode LoadWeaponEntry(CFFHacksterProject & proj, int index, bool showindex = false);
 
+	void PasteSwapStringBytes(bool swapping, CFFHacksterProject& proj, int context, int sourceindex, int destindex);
 	void SwapStringBytes(CFFHacksterProject& proj, int context, int sourceindex, int destindex);
 	void OverwriteStringBytes(CFFHacksterProject& proj, int context, int sourceindex, int destindex);
 

--- a/src/libs/ff1-utils/ui_helpers.cpp
+++ b/src/libs/ff1-utils/ui_helpers.cpp
@@ -305,6 +305,13 @@ namespace Ui
 		box.SetCurSel(prevsel);
 	}
 
+	CString GetItemText(CListBox& box, int index)
+	{
+		CString text;
+		box.GetText(index, text);
+		return text;
+	}
+
 	int FindIndexByData(CComboBox & box, DWORD_PTR data)
 	{
 		for (int i = 0; i < box.GetCount(); ++i) {
@@ -358,6 +365,15 @@ namespace Ui
 	{
 		int cursel = box.GetCurSel();
 		return cursel != CB_ERR ? box.GetItemData(cursel) : defvalue;
+	}
+
+	int ItemFromPoint(CListBox& box, CPoint mousepoint)
+	{
+		BOOL bOutside = FALSE;
+		CPoint point = mousepoint;
+		box.ScreenToClient(&point);
+		auto selindex = box.ItemFromPoint(point, bOutside);
+		return (selindex == LB_ERR) ? -1 : selindex;
 	}
 
 	int LoadCombo(CComboBox & combo, dataintnodevector dvec)

--- a/src/libs/ff1-utils/ui_helpers.h
+++ b/src/libs/ff1-utils/ui_helpers.h
@@ -83,6 +83,8 @@ namespace Ui
 	void ReplaceString(CComboBox& box, int index, CString newstring);
 	void ReplaceString(CListBox& box, int index, CString newstring);
 
+	CString GetItemText(CListBox& box, int index);
+
 	int FindIndexByData(CComboBox & box, DWORD_PTR data);
 	int FindIndexByPrefix(CComboBox & box, int matchvalue);
 	DWORD_PTR GetSelectedItemData(CComboBox & box, DWORD_PTR defvalue = -1);
@@ -91,6 +93,8 @@ namespace Ui
 	void SelectFirstItem(CComboBox & box);
 	bool SelectItemByData(CComboBox & box, DWORD_PTR data);
 	DWORD_PTR GetSelectedItemData(CListBox & box, DWORD_PTR defvalue = -1);
+
+	int ItemFromPoint(CListBox& box, CPoint mousepoint);
 
 	int LoadCombo(CComboBox & combo, dataintnodevector dvec);
 	int LoadListBox(CListBox & list, dataintnodevector dvec);


### PR DESCRIPTION
Added ability to right-click Copy on the armor list, then paste or swap.
Uses the same paste-swap dialog prompt as the Classes editor, with armor-specific options.
Streamlined the implementation for the Armor editor.
NOTE: I _**did not**_ streamline the corresponding code for the Classes editor since it wasn't in scope for this change.