### PR TITLE
Classes Editor inaccurate magic perm copyswap

### DIFF
--- a/src/apps/FFHacksterEx/FFHacksterEx.values.template
+++ b/src/apps/FFHacksterEx/FFHacksterEx.values.template
@@ -822,6 +822,11 @@ value=8
 desc=Number of spell levels in the magic engine
 type=uint8
 group=Inventory and Counts
+[SPELLSPERLEVEL_COUNT]
+value=8
+desc=Number of spells on a single magic level
+type=uint8
+group=Inventory and Counts
 [POTIONSTART_INDEX]
 value=24
 desc=0-based index iof the first potion item

--- a/src/libs/ff1-coredefs/upgrade_functions.cpp
+++ b/src/libs/ff1-coredefs/upgrade_functions.cpp
@@ -877,7 +877,8 @@ namespace Upgrades
 			return{ false, "Can't upgrade the values file because it can't be found" };
 
 		ImportStringsFromTemplates(projectini, stringsini, "ARMORTYPELABELS", "ARMORTYPE_COUNT");
-		ImportValuesFromTemplates(projectini, valuesini, { "ARMORTYPE_COUNT", "ARMORTYPE_OFFSET", "SPELLLEVEL_COUNT" });
+		ImportValuesFromTemplates(projectini, valuesini,
+			{ "ARMORTYPE_COUNT", "ARMORTYPE_OFFSET", "SPELLLEVEL_COUNT", "SPELLSPERLEVEL_COUNT" });
 		return { true, "" };
 	}
 

--- a/src/libs/ff1-editors/Classes.cpp
+++ b/src/libs/ff1-editors/Classes.cpp
@@ -448,6 +448,7 @@ void CClasses::LoadOffsets()
 	MAGIC_COUNT = ReadDec(Project->ValuesPath, "MAGIC_COUNT");
 	MAGICPERMISSIONS_OFFSET = ReadHex(Project->ValuesPath, "MAGICPERMISSIONS_OFFSET");
 	SPELLLEVEL_COUNT = ReadDec(Project->ValuesPath, "SPELLLEVEL_COUNT");
+	SPELLSPERLEVEL_COUNT = ReadDec(Project->ValuesPath, "SPELLSPERLEVEL_COUNT");
 }
 
 void CClasses::LoadRom()
@@ -1664,7 +1665,7 @@ void CClasses::PasteUsables(int srcindex, int destindex, int flags)
 	if ((flags & PASTE_MAGICPERM) == PASTE_MAGICPERM) {
 		int SPELLSPERLEVEL_COUNT = 8;
 		copypaste_helpers::CopySwapBuffer(swapping, Project->ROM, srcindex, destindex,
-			(int)MAGICPERMISSIONS_OFFSET, SPELLSPERLEVEL_COUNT, 0, (int)SPELLLEVEL_COUNT);
+			MAGICPERMISSIONS_OFFSET, SPELLSPERLEVEL_COUNT, 0, SPELLLEVEL_COUNT);
 	}
 }
 

--- a/src/libs/ff1-editors/Classes.cpp
+++ b/src/libs/ff1-editors/Classes.cpp
@@ -4,6 +4,7 @@
 #include "Classes.h"
 #include "AsmFiles.h"
 #include "collection_helpers.h"
+#include <copypaste_helpers.h>
 #include "DRAW_STRUCT.h"
 #include "FFHacksterProject.h"
 #include "GameSerializer.h"
@@ -1661,11 +1662,9 @@ void CClasses::PasteUsables(int srcindex, int destindex, int flags)
 			12, 0, ARMOR_COUNT);
 	}
 	if ((flags & PASTE_MAGICPERM) == PASTE_MAGICPERM) {
-		CopySwapBits16(swapping, MAGICPERMISSIONS_OFFSET, srcindex, destindex,
-			8, 0, MAGIC_COUNT);
-		size_t srcoffset = MAGICPERMISSIONS_OFFSET + (size_t(srcindex) * 8);
-		size_t dstoffset = MAGICPERMISSIONS_OFFSET + (size_t(destindex) * 8);
-		CopySwapBytes(swapping, srcoffset, dstoffset, 0, SPELLLEVEL_COUNT);
+		int SPELLSPERLEVEL_COUNT = 8;
+		copypaste_helpers::CopySwapBuffer(swapping, Project->ROM, srcindex, destindex,
+			(int)MAGICPERMISSIONS_OFFSET, SPELLSPERLEVEL_COUNT, 0, (int)SPELLLEVEL_COUNT);
 	}
 }
 

--- a/src/libs/ff1-editors/Classes.h
+++ b/src/libs/ff1-editors/Classes.h
@@ -114,8 +114,9 @@ protected:
 	size_t ARMOR_COUNT = (size_t)-1;
 	size_t ARMORPERMISSIONS_OFFSET = (size_t)-1;
 	size_t MAGIC_COUNT = (size_t)-1;
-	size_t MAGICPERMISSIONS_OFFSET = (size_t)-1;
-	size_t SPELLLEVEL_COUNT = (size_t)-1;
+	int MAGICPERMISSIONS_OFFSET = -1;
+	int SPELLLEVEL_COUNT = -1;
+	int SPELLSPERLEVEL_COUNT = -1;
 
 	// Battle sprite offsets
 	unsigned int CHARBATTLEPALETTE_ASSIGNMENT1 = (unsigned int)-1; // bank 0C


### PR DESCRIPTION
The editor now uses a buffer copy approach instead of bit flipping, which doesn't fit the magic permissions scenario.