### PR TITLE
Added swap to Magic editor, cleanup for Magic, Weapon, Armor editors

### DIFF
--- a/src/libs/ff1-editors/Armor.cpp
+++ b/src/libs/ff1-editors/Armor.cpp
@@ -310,11 +310,14 @@ void CArmor::HandleArmorListContextMenu(CWnd* pWnd, CPoint point)
 		if (flags[5]) CopySwapBuffer(swap, Project->ROM, m_selitem, thisitem, ARMORPRICE_OFFSET, 2, 0, 2);
 		if (flags[6]) CopySwapBuffer(swap, Project->ROM, m_selitem, thisitem, ARMORPERMISSIONS_OFFSET, 2, 0, 2);
 		if (flags[7]) CopySwapBuffer(swap, Project->ROM, m_selitem, thisitem, ARMORTYPE_OFFSET, 1, 0, 1);
+
+		m_armorlist.SetCurSel(cur = thisitem);
 		LoadValues();
 		break;
 	}
 	default:
-		if (!result.message.IsEmpty()) AfxMessageBox(result.message);
+		if (!result.message.IsEmpty())
+			throw std::runtime_error((LPCSTR)result.message);
 		break;
 	}
 }
@@ -331,6 +334,6 @@ void CArmor::DoCopySwapName(bool swap, int srcitem, int dstitem)
 		Ui::ReplaceString(m_armorlist, srcitem, srcname);
 		Ui::ReplaceString(m_armorlist, dstitem, dstname);
 	} catch(std::exception & ex) {
-		AfxMessageBox(CString("Copy/Swap operation failed:\n") + ex.what());
+		throw std::runtime_error("Copy/Swap operation failed: " + std::string(ex.what()));
 	}
 }

--- a/src/libs/ff1-editors/Magic.h
+++ b/src/libs/ff1-editors/Magic.h
@@ -47,9 +47,10 @@ protected:
 
 	void ChangeOutBattles(bool);
 
-	void CopySpell(int classindex);
+	//void HandleMagicListContextMenu(CWnd* pWnd, CPoint point);
+
 	void HandleMagicListContextMenu(CWnd* pWnd, CPoint point);
-	void PasteSpell(int srcindex, int destindex, int flags);
+	void DoCopySwapName(bool swap, int srcitem, int dstitem);
 
 	bool haltwrite;
 	std::vector<int> m_oobmagicoffsets;
@@ -65,6 +66,7 @@ protected:
 	int BATTLEMESSAGETEXT_START = -1;
 	int NOTHINGHAPPENS_OFFSET = -1;
 	unsigned int MAGICPERMISSIONS_OFFSET = (unsigned int)-1;
+	unsigned int SPELLLEVEL_COUNT = (unsigned int)-1;
 	unsigned int BATTLEMESSAGE_OFFSET = (unsigned int)-1;
 	int WEAPONMAGICGRAPHIC_OFFSET = -1;
 

--- a/src/libs/ff1-editors/Weapon.cpp
+++ b/src/libs/ff1-editors/Weapon.cpp
@@ -407,11 +407,14 @@ void CWeapon::HandleWeaponListContextMenu(CWnd* pWnd, CPoint point)
 		if (flags[0]) DoCopySwapName(swap, m_selitem, thisitem);
 		if (flags[9]) CopySwapBuffer(swap, Project->ROM, m_selitem, thisitem, WEAPONPRICE_OFFSET, 2, 0, 2);
 		if (flags[10]) CopySwapBuffer(swap, Project->ROM, m_selitem, thisitem, WEAPONPERMISSIONS_OFFSET, 2, 0, 2);
+
+		m_weaponlist.SetCurSel(cur = thisitem);
 		LoadValues();
 		break;
 	}
 	default:
-		if (!result.message.IsEmpty()) AfxMessageBox(result.message);
+		if (!result.message.IsEmpty())
+			throw std::runtime_error((LPCSTR)result.message);
 		break;
 	}
 }
@@ -429,7 +432,7 @@ void CWeapon::DoCopySwapName(bool swap, int srcitem, int dstitem)
 		Ui::ReplaceString(m_weaponlist, dstitem, dstname);
 	}
 	catch (std::exception& ex) {
-		AfxMessageBox(CString("Copy/Swap operation failed:\n") + ex.what());
+		throw std::runtime_error("Copy/Swap operation failed: " + std::string(ex.what()));
 	}
 }
 

--- a/src/libs/ff1-subeditors/copypaste_helpers.h
+++ b/src/libs/ff1-subeditors/copypaste_helpers.h
@@ -22,8 +22,10 @@ namespace copypaste_helpers
 		int baseoffset, int recwidth, int start, std::vector<bool> flags);
 	void CopySwapBuffer(bool swap, std::vector<unsigned char>& rom, int srcindex, int dstindex,
 		int baseoffset, int recwidth, int start, int bytecount);
-	void CopySwapPermissions(bool swap, std::vector<unsigned char>& rom, size_t srcindex, size_t destindex,
+	void CopySwapItemPermissions(bool swap, std::vector<unsigned char>& rom, size_t srcindex, size_t destindex,
 		size_t baseoffset, size_t bits, size_t start, size_t count);
+	void CopySwapSpellPermissions(bool swap, std::vector<unsigned char>& rom, size_t srcindex, size_t destindex,
+		size_t baseoffset, size_t bits, int recwidth, size_t start, size_t count);
 
 	struct sCopySwapResult
 	{


### PR DESCRIPTION
Added swap to Magic editor.
Cleaned up magic permissions paste (it had intermittent paste errors where 1 or 2 additional bits would be set).
Now Magic, Weapon, and Armor copy/swap throw on errors.