### PR TITLE
#152 The checkboxes will not respond to ENTER

### DIFF
--- a/src/apps/FFHacksterEx/DlgAppSettings.h
+++ b/src/apps/FFHacksterEx/DlgAppSettings.h
@@ -43,9 +43,9 @@ protected:
 	CClearButton m_exebrowsebutton;
 	CClearButton m_clearmrubutton;
 	CClearButton m_clearinvalidmrubutton;
-	CClearButton m_enforceasmcompatcheck;
-	CClearButton m_warnasmcompatcheck;
-	CClearButton m_usefolderprefscheck;
+	CClearCheckBox m_enforceasmcompatcheck;
+	CClearCheckBox m_warnasmcompatcheck;
+	CClearCheckBox m_usefolderprefscheck;
 	CClearStatic m_exestatic;
 	CClearEdit m_editRunExe;
 	CClearEdit m_cmdparamsedit;


### PR DESCRIPTION
The check boxes were using the translucency-enable CClearButton class.
Not sure if that's still needed, so I switched them to instead use the CClearCheckBox class.